### PR TITLE
Pass option name as parameter to reviver function

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Options with a value:
   The function is executed when the option is parsed. It is similar to the reviver parameter of the `JSON.parse()` function. This is the right place where you can validate the input data and `fail()` if it's not valid. For example, if the option requires a number you can validate the range here.
 
   ```javascript
-  .option ({ long: "name", metavar: "STR", reviver: function (value){
+  .option ({ long: "name", metavar: "STR", reviver: function (value, option){
     return value + "bar";
   }})
   ```

--- a/lib/argp.js
+++ b/lib/argp.js
@@ -238,7 +238,7 @@ Argp.prototype._newOption = function (o){
 
       //Use the reviver, if any
       if (o.opt.reviver){
-        o.value = o.opt.reviver.call (this, o.value);
+        o.value = o.opt.reviver.call (this, o.value, o.long || o.short);
       }
     }else if (o.value === undefined){
       //Undefined and no input value, set null


### PR DESCRIPTION
Here's a small change to the invocation of an option's reviver function that informs the function of the option name. This allows reviver functions to fail with error messages written in the same style as the default ones provided by argp, e.g.:

``` javascript
reviver: function(value, option) {
  if (value > 5) {
    this.fail("Option '" + option + "' is not under 5");
  } else {
    return value;
  }
}
```

Without this `option` parameter, the reviver function doesn't know whether the user supplied the short or long version of the option, and can't produce that style of error message.
